### PR TITLE
Handle inventory overrides and rollups

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This solution contains two projects:
 
-- **CJMSS.Plugins** (.NET Framework 4.6.2): sample `IPlugin` for `pdg_inventoryitem`.
+- **CJMSS.Plugins** (.NET Framework 4.6.2): sample plugins for both `pdg_inventoryitem` and `pdg_inventory`.
 - **CJMSS.WebResources** (.NET 8 project that simply carries files): your existing `item.form.js` and `item.form.xml.txt` for the model-driven form.
 
 ## Build
@@ -16,12 +16,18 @@ Use the **Plugin Registration Tool** (XrmTooling) and register:
 - Assembly: `CJMSS.Plugins.dll`
 - Step 1 (suggested): Message = `Update`, Primary Entity = `pdg_inventoryitem`, Stage = `PreOperation`
   - Pre Image: `PreImage` with `pdg_publicprice,pdg_unitcost,pdg_quantityonhand,pdg_grossweight,pdg_itemtype`
+- Step 2 (optional): Message = `Create` & `Update`, Primary Entity = `pdg_inventory`, Stage = `PostOperation`
+  - Pre Image: `PreImage` with `pdg_inventoryitem,pdg_grossweight`
 
-The sample plugin:
+The sample plugins:
 
-- Requires **Gross Weight** and **Public Price** for jewelry items (Item Type option value `100000001` — update to match your environment).
-- Blocks updates when **Public Price ≤ Unit Cost**.
-- Sets **Total Value** = **Quantity On Hand** × **Unit Cost**.
+- For `pdg_inventoryitem`:
+  - Requires **Gross Weight** and **Public Price** for jewelry items (Item Type option value `100000001` — update to match your environment).
+  - Blocks updates when **Public Price ≤ Unit Cost**.
+  - Sets **Total Value** = **Quantity On Hand** × **Unit Cost**.
+- For `pdg_inventory`:
+  - Treats fields as per-lot overrides (e.g., **Gross Weight**).
+  - Rolls up the average lot weight back to the related `pdg_inventoryitem` so the item retains the baseline value.
 
 ## Deploy the web resources
 
@@ -29,6 +35,8 @@ Add `webresources/item.form.js` as a JavaScript web resource in your solution an
 
 ## Notes
 
-- The plugin mirrors validations present in your form JS and uses these logical names:
+- Baseline attributes such as **Unit Cost** and **Public Price** remain on `pdg_inventoryitem`.
+- `pdg_inventory` only keeps fields that vary per lot (currently **Gross Weight**). When the lot's weight changes, the `InventoryRollupPlugin` recomputes the average and updates the item's **Gross Weight**.
+- The plugins mirror validations present in your form JS and use these logical names:
   `pdg_publicprice`, `pdg_unitcost`, `pdg_quantityonhand`, `pdg_totalvalue`, `pdg_grossweight`, `pdg_itemtype`.
 - Adjust the jewelry OptionSet value to match your environment if different.

--- a/src/CJMSS.Plugins/Plugins/Inventory/InventoryRollupPlugin.cs
+++ b/src/CJMSS.Plugins/Plugins/Inventory/InventoryRollupPlugin.cs
@@ -1,0 +1,93 @@
+using System;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace CJMSS.Plugins.Plugins.Inventory
+{
+    /// <summary>
+    /// Plugin for <c>pdg_inventory</c> that handles per-lot overrides and rolls values back to
+    /// the related <c>pdg_inventoryitem</c>.
+    ///
+    /// Baseline attributes like unit cost and public price live on <c>pdg_inventoryitem</c>.
+    /// The inventory record only stores variations such as per-lot gross weight.
+    /// When the lot weight changes this plugin recomputes the average gross weight
+    /// across all lots and updates the item.
+    ///
+    /// Register on: Create & Update of <c>pdg_grossweight</c> for entity <c>pdg_inventory</c>.
+    /// Pre Image suggestion: "PreImage" with <c>pdg_inventoryitem,pdg_grossweight</c>.
+    /// </summary>
+    public class InventoryRollupPlugin : IPlugin
+    {
+        private const string InventoryEntity = "pdg_inventory";
+        private const string AttrLotWeight = "pdg_grossweight";
+        private const string AttrItemLookup = "pdg_inventoryitem"; // lookup to pdg_inventoryitem
+        private const string ItemEntity = "pdg_inventoryitem";
+        private const string ItemAttrGrossWeight = "pdg_grossweight"; // baseline gross weight
+
+        public void Execute(IServiceProvider serviceProvider)
+        {
+            var context = (IPluginExecutionContext)serviceProvider.GetService(typeof(IPluginExecutionContext));
+            var serviceFactory = (IOrganizationServiceFactory)serviceProvider.GetService(typeof(IOrganizationServiceFactory));
+            var service = serviceFactory.CreateOrganizationService(context.UserId);
+            var tracing = (ITracingService)serviceProvider.GetService(typeof(ITracingService));
+
+            if (!string.Equals(context.PrimaryEntityName, InventoryEntity, StringComparison.OrdinalIgnoreCase))
+                return;
+
+            if (!(context.InputParameters.Contains("Target") && context.InputParameters["Target"] is Entity target))
+                return;
+
+            Entity pre = null;
+            if (context.PreEntityImages.Contains("PreImage") && context.PreEntityImages["PreImage"] is Entity preImg)
+                pre = preImg;
+
+            // Determine parent item
+            EntityReference itemRef = null;
+            if (target.Contains(AttrItemLookup) && target[AttrItemLookup] is EntityReference er1)
+                itemRef = er1;
+            else if (pre != null && pre.Contains(AttrItemLookup) && pre[AttrItemLookup] is EntityReference er2)
+                itemRef = er2;
+
+            if (itemRef == null)
+                return; // Cannot roll up without an item
+
+            bool weightChanged = context.MessageName.Equals("Create", StringComparison.OrdinalIgnoreCase) ||
+                                 target.Contains(AttrLotWeight);
+            if (!weightChanged)
+                return; // nothing to roll up
+
+            // Retrieve all inventory lots for this item to calculate average weight
+            var query = new QueryExpression(InventoryEntity)
+            {
+                ColumnSet = new ColumnSet(AttrLotWeight)
+            };
+            query.Criteria.AddCondition(AttrItemLookup, ConditionOperator.Equal, itemRef.Id);
+
+            var lots = service.RetrieveMultiple(query).Entities;
+            decimal totalWeight = 0m;
+            int count = 0;
+            foreach (var lot in lots)
+            {
+                if (lot.Contains(AttrLotWeight) && lot[AttrLotWeight] != null)
+                {
+                    decimal w = 0m;
+                    var val = lot[AttrLotWeight];
+                    if (val is Money m) w = m.Value;
+                    else if (val is decimal d) w = d;
+                    else decimal.TryParse(val.ToString(), out w);
+                    totalWeight += w;
+                    count++;
+                }
+            }
+
+            decimal avgWeight = count > 0 ? totalWeight / count : 0m;
+
+            var itemUpdate = new Entity(ItemEntity) { Id = itemRef.Id };
+            itemUpdate[ItemAttrGrossWeight] = avgWeight;
+            service.Update(itemUpdate);
+
+            tracing.Trace($"Rolled up average gross weight {avgWeight} to item {itemRef.Id} from {count} lots.");
+        }
+    }
+}
+

--- a/src/CJMSS.Plugins/Plugins/InventoryItem/ItemCostingPlugin.cs
+++ b/src/CJMSS.Plugins/Plugins/InventoryItem/ItemCostingPlugin.cs
@@ -4,7 +4,11 @@ using Microsoft.Xrm.Sdk;
 namespace CJMSS.Plugins.Plugins.InventoryItem
 {
     /// <summary>
-    /// Sample plugin for pdg_inventoryitem that demonstrates common patterns:
+    /// Sample plugin for <c>pdg_inventoryitem</c> that demonstrates common patterns.
+    /// It operates on **baseline** item attributes such as unit cost, public price
+    /// and gross weight. Inventory-level variations are handled separately on
+    /// `pdg_inventory` and rolled back up to the item.
+    ///
     ///  - Validates jewelry requirements (gross weight & public price)
     ///  - Calculates Total Value = Unit Cost * Quantity On Hand
     ///  - Prevents saving when public price <= unit cost


### PR DESCRIPTION
## Summary
- Document baseline vs per-lot override fields and plugin registration steps
- Clarify `ItemCostingPlugin` operates on baseline item attributes
- Add `InventoryRollupPlugin` to roll up per-lot gross weight to the item

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b1097c8944832f8086c563293b6fb1